### PR TITLE
Validate refresh token before issuing new access token

### DIFF
--- a/accounts/services/auth_service.py
+++ b/accounts/services/auth_service.py
@@ -1,5 +1,5 @@
 import datetime
-from django.contrib.auth import authenticate
+from django.contrib.auth import authenticate, get_user_model
 from rest_framework.exceptions import AuthenticationFailed
 from ..jwt_utils import create_jwt, create_refresh_jwt, decode_refresh_jwt
 
@@ -19,8 +19,20 @@ class AuthService:
     def refresh_user_token(refresh_token: str) -> tuple[str, datetime.datetime]:
         if not refresh_token:
             raise AuthenticationFailed("Refresh token is missing")
-        
+
         payload = decode_refresh_jwt(refresh_token)
         user_id = payload.get("user_id")
-        token, exp = create_jwt(user_id)
+        if not user_id:
+            raise AuthenticationFailed("Invalid refresh token")
+
+        UserModel = get_user_model()
+        try:
+            user = UserModel.objects.get(pk=user_id)
+        except UserModel.DoesNotExist:
+            raise AuthenticationFailed("Invalid refresh token")
+
+        if not getattr(user, "is_active", True):
+            raise AuthenticationFailed("Invalid refresh token")
+
+        token, exp = create_jwt(user.id)
         return token, exp

--- a/tests/auth/test_refresh_token.py
+++ b/tests/auth/test_refresh_token.py
@@ -40,13 +40,30 @@ def test_refresh_token_missing(api_client, user):
     assert res.data['detail'] == "Refresh token is missing"
 
 def test_refresh_token_invalid(api_client, user):
-    payload = {"username": user.username, "password": "pass1234"} 
+    payload = {"username": user.username, "password": "pass1234"}
     res = api_client.post(LOGIN_URL, payload, format="json")
     _skip_if_404(res)
-    
+
     assert res.status_code == 200
-    
+
     api_client.cookies[REFRESH_COOKIE_NAME] = "invalid token"
+    res = api_client.post(REFRESH_URL, {}, format="json")
+    assert res.status_code == 403
+    assert res.data['detail'] == "Invalid refresh token"
+
+
+def test_refresh_token_for_deleted_user(api_client, user):
+    payload = {"username": user.username, "password": "pass1234"}
+    res = api_client.post(LOGIN_URL, payload, format="json")
+    _skip_if_404(res)
+
+    assert res.status_code == 200
+    cookie = res.cookies.get(REFRESH_COOKIE_NAME)
+    assert cookie is not None, f"{REFRESH_COOKIE_NAME} cookie not found after login"
+
+    api_client.cookies[REFRESH_COOKIE_NAME] = cookie.value
+    user.delete()
+
     res = api_client.post(REFRESH_URL, {}, format="json")
     assert res.status_code == 403
     assert res.data['detail'] == "Invalid refresh token"


### PR DESCRIPTION
## Summary
- validate refresh token payloads by requiring a user id before issuing new access tokens
- ensure the referenced user exists and is active when refreshing tokens
- add a regression test that ensures deleted users cannot refresh tokens

## Testing
- pytest tests/auth/test_refresh_token.py *(fails: missing PostgreSQL environment variables in settings)*

------
https://chatgpt.com/codex/tasks/task_e_68cb28f16ed8832e8d70dbfd697c33f0